### PR TITLE
Change in query API and small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ It requires [Scrapy](http://scrapy.org/) and [PyMongo](https://api.mongodb.org/p
 
 2. In the root folder of this project, run command like: 
 
-		scrapy crawl TweetScraper -a queries=foo,#bar
+		scrapy crawl TweetScraper -a queru=foo,#bar
 
-	where `queries` is a list of keywords seperated by comma (`,`). The queries can be any thing (keyword, hashtag, etc.) you want to search in [Twitter Search](https://twitter.com/search-home). `TweetScraper` will crawl the search results of each query and save the tweet content and user information. You can also use the following operators in each query (from [Twitter Search](https://twitter.com/search-home)):
+	where `queru` is a list of keywords seperated by comma (`,`). The query can be any thing (keyword, hashtag, etc.) you want to search in [Twitter Search](https://twitter.com/search-home). `TweetScraper` will crawl the search results of the query and save the tweet content and user information. You can also use the following operators in each query (from [Twitter Search](https://twitter.com/search-home)):
 	
 	| Operator | Finds tweets... |
 	| --- | --- |

--- a/TweetScraper/items.py
+++ b/TweetScraper/items.py
@@ -12,9 +12,12 @@ class Tweet(Item):
     user_id = Field()  # user id
     usernameTweet = Field() # username of tweet
 
-    nbr_retweet = Field()
-    nbr_favorite = Field()
-    nbr_reply = Field()
+    nbr_retweet = Field()  # nbr of retweet
+    nbr_favorite = Field() # nbr of favorite
+    nbr_reply = Field()    # nbr of reply
+
+    is_reply = Field()   # boolean if the tweet is a reply or not
+    is_retweet = Field() # boolean if the tweet is just a retweet of another tweet
 
     has_image = Field() # True/False, whether a tweet contains images
     images = Field()    # a list of image urls, empty if none

--- a/TweetScraper/items.py
+++ b/TweetScraper/items.py
@@ -10,7 +10,7 @@ class TweetItem(Item):
     datetime = Field() # post time
     text = Field()     # text content
     user_id = Field()  # user id
-    
+
     has_image = Field() # True/False, whether a tweet contains images
     images = Field()    # a list of image urls, empty if none
 
@@ -26,4 +26,3 @@ class UserItem(Item):
     name = Field()          # user name
     screen_name = Field()   # user screen name
     avatar = Field()        # avator url
-    

--- a/TweetScraper/items.py
+++ b/TweetScraper/items.py
@@ -10,6 +10,10 @@ class TweetItem(Item):
     datetime = Field() # post time
     text = Field()     # text content
     user_id = Field()  # user id
+    usernameTweet = Field() # username of tweet
+
+    nbr_retweet = Field()
+    nbr_favorite = Field()
 
     has_image = Field() # True/False, whether a tweet contains images
     images = Field()    # a list of image urls, empty if none

--- a/TweetScraper/items.py
+++ b/TweetScraper/items.py
@@ -4,7 +4,7 @@
 from scrapy import Item, Field
 
 
-class TweetItem(Item):
+class Tweet(Item):
     ID = Field()       # tweet id
     url = Field()      # tweet url
     datetime = Field() # post time
@@ -14,6 +14,7 @@ class TweetItem(Item):
 
     nbr_retweet = Field()
     nbr_favorite = Field()
+    nbr_reply = Field()
 
     has_image = Field() # True/False, whether a tweet contains images
     images = Field()    # a list of image urls, empty if none
@@ -25,7 +26,7 @@ class TweetItem(Item):
     medias = Field()    # a list of media
 
 
-class UserItem(Item):
+class User(Item):
     ID = Field()            # user id
     name = Field()          # user name
     screen_name = Field()   # user screen name

--- a/TweetScraper/pipelines.py
+++ b/TweetScraper/pipelines.py
@@ -6,27 +6,27 @@ import pymongo
 import json
 import os
 
-from TweetScraper.items import TweetItem,UserItem
+from TweetScraper.items import TweetItem, UserItem
 from TweetScraper.utils import mkdirs
 
 
 logger = logging.getLogger(__name__)
 
 class SaveToMongoPipeline(object):
-    
+
     ''' pipeline that save data to mongodb '''
     def __init__(self):
         connection = pymongo.MongoClient(settings['MONGODB_SERVER'], settings['MONGODB_PORT'])
         db = connection[settings['MONGODB_DB']]
         self.tweetCollection = db[settings['MONGODB_TWEET_COLLECTION']]
         self.userCollection = db[settings['MONGODB_USER_COLLECTION']]
-        self.tweetCollection.ensure_index([('ID',pymongo.ASCENDING)], unique=True, dropDups=True)
-        self.userCollection.ensure_index([('ID',pymongo.ASCENDING)], unique=True, dropDups=True)
+        self.tweetCollection.ensure_index([('ID', pymongo.ASCENDING)], unique=True, dropDups=True)
+        self.userCollection.ensure_index([('ID', pymongo.ASCENDING)], unique=True, dropDups=True)
 
 
     def process_item(self, item, spider):
         if isinstance(item, TweetItem):
-            dbItem = self.tweetCollection.find_one({'ID':item['ID']})
+            dbItem = self.tweetCollection.find_one({'ID': item['ID']})
             if dbItem:
                 pass # simply skip existing items
                 ### or you can update the tweet, if you don't want to skip:
@@ -35,10 +35,10 @@ class SaveToMongoPipeline(object):
                 # logger.info("Update tweet:%s"%dbItem['url'])
             else:
                 self.tweetCollection.insert_one(dict(item))
-                logger.info("Add tweet:%s"%item['url'])
+                logger.info("Add tweet:%s" %item['url'])
 
         elif isinstance(item, UserItem):
-            dbItem = self.userCollection.find_one({'ID':item['ID']})
+            dbItem = self.userCollection.find_one({'ID': item['ID']})
             if dbItem:
                 pass # simply skip existing items
                 ### or you can update the user, if you don't want to skip:
@@ -47,10 +47,10 @@ class SaveToMongoPipeline(object):
                 # logger.info("Update user:%s"%dbItem['screen_name'])
             else:
                 self.userCollection.insert_one(dict(item))
-                logger.info("Add user:%s"%item['screen_name'])
+                    logger.info("Add user:%s" %item['screen_name']
 
         else:
-            logger.info("Item type is not recognised! type = %s"%type(item))
+            logger.info("Item type is not recognized! type = %s" %type(item))
 
 
 
@@ -73,7 +73,7 @@ class SaveToFilePipeline(object):
                 # logger.info("Update tweet:%s"%dbItem['url'])
             else:
                 self.save_to_file(item,savePath)
-                logger.info("Add tweet:%s"%item['url'])
+                logger.info("Add tweet:%s" %item['url'])
 
         elif isinstance(item, UserItem):
             savePath = os.path.join(self.saveUserPath, item['ID'])
@@ -83,11 +83,11 @@ class SaveToFilePipeline(object):
                 # self.save_to_file(item,savePath)
                 # logger.info("Update user:%s"%dbItem['screen_name'])
             else:
-                self.save_to_file(item,savePath)
-                logger.info("Add user:%s"%item['screen_name'])
+                self.save_to_file(item, savePath)
+                logger.info("Add user:%s" %item['screen_name'])
 
         else:
-            logger.info("Item type is not recognised! type = %s"%type(item))
+            logger.info("Item type is not recognised! type = %s" %type(item))
 
 
     def save_to_file(self, item, fname):
@@ -96,4 +96,4 @@ class SaveToFilePipeline(object):
                 fname - where to save
         '''
         with open(fname,'w') as f:
-            json.dump(dict(item),f)
+            json.dump(dict(item), f)

--- a/TweetScraper/pipelines.py
+++ b/TweetScraper/pipelines.py
@@ -87,7 +87,7 @@ class SaveToFilePipeline(object):
                 logger.info("Add user:%s" %item['screen_name'])
 
         else:
-            logger.info("Item type is not recognised! type = %s" %type(item))
+            logger.info("Item type is not recognized! type = %s" %type(item))
 
 
     def save_to_file(self, item, fname):

--- a/TweetScraper/pipelines.py
+++ b/TweetScraper/pipelines.py
@@ -6,7 +6,7 @@ import pymongo
 import json
 import os
 
-from TweetScraper.items import TweetItem, UserItem
+from TweetScraper.items import Tweet, User
 from TweetScraper.utils import mkdirs
 
 
@@ -25,7 +25,7 @@ class SaveToMongoPipeline(object):
 
 
     def process_item(self, item, spider):
-        if isinstance(item, TweetItem):
+        if isinstance(item, Tweet):
             dbItem = self.tweetCollection.find_one({'ID': item['ID']})
             if dbItem:
                 pass # simply skip existing items
@@ -37,7 +37,7 @@ class SaveToMongoPipeline(object):
                 self.tweetCollection.insert_one(dict(item))
                 logger.info("Add tweet:%s" %item['url'])
 
-        elif isinstance(item, UserItem):
+        elif isinstance(item, User):
             dbItem = self.userCollection.find_one({'ID': item['ID']})
             if dbItem:
                 pass # simply skip existing items
@@ -64,7 +64,7 @@ class SaveToFilePipeline(object):
 
 
     def process_item(self, item, spider):
-        if isinstance(item, TweetItem):
+        if isinstance(item, Tweet):
             savePath = os.path.join(self.saveTweetPath, item['ID'])
             if os.path.isfile(savePath):
                 pass # simply skip existing items
@@ -75,7 +75,7 @@ class SaveToFilePipeline(object):
                 self.save_to_file(item,savePath)
                 logger.info("Add tweet:%s" %item['url'])
 
-        elif isinstance(item, UserItem):
+        elif isinstance(item, User):
             savePath = os.path.join(self.saveUserPath, item['ID'])
             if os.path.isfile(savePath):
                 pass # simply skip existing items

--- a/TweetScraper/pipelines.py
+++ b/TweetScraper/pipelines.py
@@ -47,7 +47,7 @@ class SaveToMongoPipeline(object):
                 # logger.info("Update user:%s"%dbItem['screen_name'])
             else:
                 self.userCollection.insert_one(dict(item))
-                    logger.info("Add user:%s" %item['screen_name']
+                logger.info("Add user:%s" %item['screen_name'])
 
         else:
             logger.info("Item type is not recognized! type = %s" %type(item))

--- a/TweetScraper/spiders/TweetCrawler.py
+++ b/TweetScraper/spiders/TweetCrawler.py
@@ -128,6 +128,12 @@ class TweetScraper(CrawlSpider):
                         logger.debug('Not handle "data-card2-type":\n%s'%item.xpath('.').extract()[0])
 
 
+                is_reply = item.xpath('.//div[@class="ReplyingToContextBelowAuthor"]').extract()
+                tweet['is_reply'] = is_reply != []
+
+                is_retweet = item.xpath('.//span[@class="js-retweet-text"]').extract()
+                tweet['is_retweet'] = is_retweet != []
+
                 tweet['user_id'] = item.xpath('.//@data-user-id').extract()[0]
                 yield tweet
 

--- a/TweetScraper/spiders/TweetCrawler.py
+++ b/TweetScraper/spiders/TweetCrawler.py
@@ -10,6 +10,7 @@ import time
 import logging
 import urllib
 import urlparse
+from datetime import datetime
 
 from TweetScraper.items import Tweet, User
 
@@ -22,13 +23,11 @@ class TweetScraper(CrawlSpider):
 
     def __init__(self, query='', crawl_user=False):
         self.query = query
-        print query
         self.url = "https://twitter.com/i/search/timeline?f=tweets&q=%s&src=typed&max_position=%s"
         self.crawl_user = crawl_user
 
     def start_requests(self):
         url = self.url %(urllib.quote(' '.join(self.query.split(','))), '')
-        print url
         yield http.Request(url, callback=self.parse_page)
 
 
@@ -93,7 +92,7 @@ class TweetScraper(CrawlSpider):
                 else:
                     tweet['nbr_reply'] = 0
 
-                tweet['datetime'] = item.xpath('.//div[@class="stream-item-header"]/small[@class="time"]/a/span/@data-time').extract()[0]
+                tweet['datetime'] = datetime.fromtimestamp(int(item.xpath('.//div[@class="stream-item-header"]/small[@class="time"]/a/span/@data-time').extract()[0])).strftime('%Y-%m-%d %H:%M:%S')
 
                 ### get photo
                 has_cards = item.xpath('.//@data-card-type').extract()

--- a/TweetScraper/spiders/TweetCrawler.py
+++ b/TweetScraper/spiders/TweetCrawler.py
@@ -40,7 +40,7 @@ class TweetScraper(CrawlSpider):
         # get next page
         min_position = data['min_position']
         url = self.url %(urllib.quote_plus(self.query), min_position)
-        yield http.Request(url, callback=self.parse_more_page)
+        yield http.Request(url, callback=self.parse_page)
 
 
     def parse_tweets_block(self, html_page):

--- a/TweetScraper/spiders/TweetCrawler.py
+++ b/TweetScraper/spiders/TweetCrawler.py
@@ -11,7 +11,7 @@ import logging
 import urllib
 import urlparse
 
-from TweetScraper.items import TweetItem, UserItem
+from TweetScraper.items import Tweet, User
 
 
 logger = logging.getLogger(__name__)
@@ -20,18 +20,17 @@ class TweetScraper(CrawlSpider):
     name = 'TweetScraper'
     allowed_domains = ['twitter.com']
 
-    def __init__(self, query=''):
+    def __init__(self, query='', crawl_user=False):
         self.query = query
-        self.reScrollCursor = re.compile(r'data-min-position="([^"]+?)"')
-        self.reRefreshCursor = re.compile(r'data-refresh-cursor="([^"]+?)"')
         self.url = "https://twitter.com/i/search/timeline?&f=tweets&q=%s&src=typed&max_position=%s"
+        self.crawl_user = crawl_user
 
     def start_requests(self):
         url = self.url %(urllib.quote_plus(self.query)[0], '')
-        yield http.Request(url, callback=self.parse_more_page)
+        yield http.Request(url, callback=self.parse_page)
 
 
-    def parse_more_page(self, response):
+    def parse_page(self, response):
         # inspect_response(response)
         # handle current page
         data = json.loads(response.body)
@@ -56,43 +55,49 @@ class TweetScraper(CrawlSpider):
     def parse_tweet_item(self, items):
         for item in items:
             try:
-                tweetItem = TweetItem()
-                userItem = UserItem()
+                tweet = Tweet()
 
-                tweetItem['usernameTweet'] = item.xpath('.//span[@class="username u-dir"]/b/text()').extract()[0]
+                tweet['usernameTweet'] = item.xpath('.//span[@class="username u-dir"]/b/text()').extract()[0]
 
                 ID = item.xpath('.//@data-tweet-id').extract()
                 if not ID:
                     continue
-                tweetItem['ID'] = ID[0]
+                tweet['ID'] = ID[0]
 
                 ### get text content
-                tweetItem['text'] = ' '.join(item.xpath('.//div[@class="js-tweet-text-container"]/p//text()').extract()).replace(' # ', '#').replace(' @ ', '@')
-                if tweetItem['text'] == '':
-                    continue #skip no <p> tweet
+                tweet['text'] = ' '.join(item.xpath('.//div[@class="js-tweet-text-container"]/p//text()').extract()).replace(' # ', '#').replace(' @ ', '@')
+                if tweet['text'] == '':
+                    # If there is not text, we ignore the tweet
+                    continue
 
                 ### get meta data
-                tweetItem['url'] = item.xpath('.//@data-permalink-path').extract()[0]
+                tweet['url'] = item.xpath('.//@data-permalink-path').extract()[0]
 
                 nbr_retweet = item.xpath('.//button[@data-modal="ProfileTweet-retweet"]/div[2]/span/span/text()').extract()
                 if nbr_retweet:
-                    tweetItem['nbr_retweet'] = int(nbr_retweet[0])
+                    tweet['nbr_retweet'] = int(nbr_retweet[0])
                 else:
-                    tweetItem['nbr_retweet'] = 0
+                    tweet['nbr_retweet'] = 0
 
                 nbr_favorite = item.xpath('.//button[@class="ProfileTweet-actionButton js-actionButton js-actionFavorite"]/div[2]/span/span/text()').extract()
                 if nbr_favorite:
-                    tweetItem['nbr_favorite'] = int(nbr_favorite[0])
+                    tweet['nbr_favorite'] = int(nbr_favorite[0])
                 else:
-                    tweetItem['nbr_favorite'] = 0
+                    tweet['nbr_favorite'] = 0
 
-                tweetItem['datetime'] = item.xpath('.//div[@class="stream-item-header"]/small[@class="time"]/a/span/@data-time').extract()[0]
+                nbr_reply = item.xpath('.//button[@class="ProfileTweet-actionButton js-actionButton js-actionReply"]/div[2]/span/span/text()').extract()
+                if nbr_reply:
+                    tweet['nbr_reply'] = int(nbr_reply[0])
+                else:
+                    tweet['nbr_reply'] = 0
+
+                tweet['datetime'] = item.xpath('.//div[@class="stream-item-header"]/small[@class="time"]/a/span/@data-time').extract()[0]
 
                 ### get photo
                 has_cards = item.xpath('.//@data-card-type').extract()
                 if has_cards and has_cards[0] == 'photo':
-                    tweetItem['has_image'] = True
-                    tweetItem['images'] = item.xpath('.//*/div/@data-image-url').extract()
+                    tweet['has_image'] = True
+                    tweet['images'] = item.xpath('.//*/div/@data-image-url').extract()
                 elif has_cards:
                     logger.debug('Not handle "data-card-type":\n%s'%item.xpath('.').extract()[0])
 
@@ -100,37 +105,39 @@ class TweetScraper(CrawlSpider):
                 has_cards = item.xpath('.//@data-card2-type').extract()
                 if has_cards:
                     if has_cards[0] == 'animated_gif':
-                        tweetItem['has_video'] = True
-                        tweetItem['videos'] = item.xpath('.//*/source/@video-src').extract()
+                        tweet['has_video'] = True
+                        tweet['videos'] = item.xpath('.//*/source/@video-src').extract()
                     elif has_cards[0] == 'player':
-                        tweetItem['has_media'] = True
-                        tweetItem['medias'] = item.xpath('.//*/div/@data-card-url').extract()
+                        tweet['has_media'] = True
+                        tweet['medias'] = item.xpath('.//*/div/@data-card-url').extract()
                     elif has_cards[0] == 'summary_large_image':
-                        tweetItem['has_media'] = True
-                        tweetItem['medias'] = item.xpath('.//*/div/@data-card-url').extract()
+                        tweet['has_media'] = True
+                        tweet['medias'] = item.xpath('.//*/div/@data-card-url').extract()
                     elif has_cards[0] == 'amplify':
-                        tweetItem['has_media'] = True
-                        tweetItem['medias'] = item.xpath('.//*/div/@data-card-url').extract()
+                        tweet['has_media'] = True
+                        tweet['medias'] = item.xpath('.//*/div/@data-card-url').extract()
                     elif has_cards[0] == 'summary':
-                        tweetItem['has_media'] = True
-                        tweetItem['medias'] = item.xpath('.//*/div/@data-card-url').extract()
+                        tweet['has_media'] = True
+                        tweet['medias'] = item.xpath('.//*/div/@data-card-url').extract()
                     elif has_cards[0] == '__entity_video':
                         pass # TODO
-                        # tweetItem['has_media'] = True
-                        # tweetItem['medias'] = item.xpath('.//*/div/@data-src').extract()
+                        # tweet['has_media'] = True
+                        # tweet['medias'] = item.xpath('.//*/div/@data-src').extract()
                     else: # there are many other types of card2 !!!!
                         logger.debug('Not handle "data-card2-type":\n%s'%item.xpath('.').extract()[0])
 
-                ### get user info
-                tweetItem['user_id'] = item.xpath('.//@data-user-id').extract()[0]
-                userItem['ID'] = tweetItem['user_id']
-                userItem['name'] = item.xpath('.//@data-name').extract()[0]
-                userItem['screen_name'] = item.xpath('.//@data-screen-name').extract()[0]
-                userItem['avatar'] = \
-                    item.xpath('.//div[@class="content"]/div[@class="stream-item-header"]/a/img/@src').extract()[0]
 
-                yield tweetItem
-                yield userItem
+                tweet['user_id'] = item.xpath('.//@data-user-id').extract()[0]
+                yield tweet
+
+                if self.crawl_user:
+                    ### get user info
+                    user['ID'] = tweet['user_id']
+                    user['name'] = item.xpath('.//@data-name').extract()[0]
+                    user['screen_name'] = item.xpath('.//@data-screen-name').extract()[0]
+                    user['avatar'] = \
+                        item.xpath('.//div[@class="content"]/div[@class="stream-item-header"]/a/img/@src').extract()[0]
+                    yield user
             except:
                 logger.error("Error tweet:\n%s"%item.xpath('.').extract()[0])
                 # raise

--- a/TweetScraper/spiders/TweetCrawler.py
+++ b/TweetScraper/spiders/TweetCrawler.py
@@ -22,11 +22,13 @@ class TweetScraper(CrawlSpider):
 
     def __init__(self, query='', crawl_user=False):
         self.query = query
-        self.url = "https://twitter.com/i/search/timeline?&f=tweets&q=%s&src=typed&max_position=%s"
+        print query
+        self.url = "https://twitter.com/i/search/timeline?f=tweets&q=%s&src=typed&max_position=%s"
         self.crawl_user = crawl_user
 
     def start_requests(self):
-        url = self.url %(urllib.quote_plus(self.query)[0], '')
+        url = self.url %(urllib.quote(' '.join(self.query.split(','))), '')
+        print url
         yield http.Request(url, callback=self.parse_page)
 
 
@@ -39,7 +41,7 @@ class TweetScraper(CrawlSpider):
 
         # get next page
         min_position = data['min_position']
-        url = self.url %(urllib.quote_plus(self.query), min_position)
+        url = self.url %(urllib.quote(self.query), min_position)
         yield http.Request(url, callback=self.parse_page)
 
 

--- a/TweetScraper/spiders/TweetCrawler.py
+++ b/TweetScraper/spiders/TweetCrawler.py
@@ -21,9 +21,12 @@ class TweetScraper(CrawlSpider):
     name = 'TweetScraper'
     allowed_domains = ['twitter.com']
 
-    def __init__(self, query='', crawl_user=False):
+    def __init__(self, query='', crawl_user=False, top_tweet=False):
         self.query = query
-        self.url = "https://twitter.com/i/search/timeline?f=tweets&q=%s&src=typed&max_position=%s"
+        if top_tweet:
+            self.url = "https://twitter.com/i/search/timeline?q=%s&src=typed&max_position=%s"
+        else:
+            self.url = "https://twitter.com/i/search/timeline?f=tweets&q=%s&src=typed&max_position=%s"
         self.crawl_user = crawl_user
 
     def start_requests(self):

--- a/TweetScraper/spiders/TweetCrawler.py
+++ b/TweetScraper/spiders/TweetCrawler.py
@@ -67,7 +67,7 @@ class TweetScraper(CrawlSpider):
                 tweetItem['ID'] = ID[0]
 
                 ### get text content
-                tweetItem['text'] = '\n'.join(item.xpath('.//div[@class="js-tweet-text-container"]/p/text()').extract()).replace('# ', '#').replace('@ ', '@')
+                tweetItem['text'] = ' '.join(item.xpath('.//div[@class="js-tweet-text-container"]/p//text()').extract()).replace(' # ', '#').replace(' @ ', '@')
                 if tweetItem['text'] == '':
                     continue #skip no <p> tweet
 

--- a/TweetScraper/spiders/TweetCrawler.py
+++ b/TweetScraper/spiders/TweetCrawler.py
@@ -29,7 +29,7 @@ class TweetScraper(CrawlSpider):
     def start_requests(self):
         # generate request: https://twitter.com/search?q=[xxx] for each query
         for query in self.queries:
-            url = 'https://twitter.com/search?q=%s'%urllib.quote_plus(query)
+            url = 'https://twitter.com/search?q=%s' %urllib.quote_plus(query)
             yield http.Request(url, callback=self.parse_search_page)
 
 
@@ -106,7 +106,6 @@ class TweetScraper(CrawlSpider):
                 tweetItem['datetime'] = \
                     item.xpath(
                         './/div[@class="content"]/div[@class="stream-item-header"]/small[@class="time"]/a/span/@data-time').extract()[0]
-                
 
                 ### get photo
                 has_cards = item.xpath('.//@data-card-type').extract()


### PR DESCRIPTION
## Motivation
I had the need to crawl twitter search page with scrapy. You library is doing a great job at it and I am proposing some change. These change are motivated by my needs but they might benefit everyone.

## Changes
**Change the query API**
The way you handled `queries` made it impossible to have a single request with several arguments, such as `from:user and to:anotheruser`. These two arguments were divided in two separated queries.
The scraper now takes a single query with several arguments, if the user wants to make multiple queries, he needs to launch several crawler instances. I though it make more senss and is closer to the actual search page interface.

* Using directly the `/timeline` search URL, making it easier to follow pages
* Add some field to Items (is_retweet, is_reply, nbr_retweet ...)
* Do not crawl user by default, just tweets
* small format and PEP8 changes