### PR TITLE
Fixes Bug #35 - Remove unwanted spaces before @, # symbols and in embedded http links…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 scrapy
 pymongo
 mysql-connector
+lxml


### PR DESCRIPTION
I'm using lxml to remove unwanted child elements of \<a\> tag in the tweet paragraph. I tried doing it with scrapy 'Selector' but I could not find a way to remove the child sub-elements of an element with 'Selector', hence using lxml.